### PR TITLE
fix: use BTreeMap to preserve keys' order

### DIFF
--- a/src/circuit_info.rs
+++ b/src/circuit_info.rs
@@ -1,12 +1,12 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CircuitInfo {
-    pub input_name_to_wire_index: HashMap<String, usize>,
-    pub constants: HashMap<String, ConstantInfo>,
-    pub output_name_to_wire_index: HashMap<String, usize>,
+    pub input_name_to_wire_index: BTreeMap<String, usize>,
+    pub constants: BTreeMap<String, ConstantInfo>,
+    pub output_name_to_wire_index: BTreeMap<String, usize>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## What is this PR doing?

`HashMap` does not preserve any particular order because its internal structure is based on hashing. However, the keys in the circuit fields should always have the same order since they could be used with hashes for integrity checks etc. Instead, `BTreeMap` has been used, which preserves the order of the keys.

See https://github.com/voltrevo/emp-wasm-backend/pull/7 for information about this issue.

After this PR is merged, it's necessary to update the dependencies on [boolify](https://github.com/voltrevo/boolify) and [summon](https://github.com/voltrevo/summon).

## How can these changes be manually tested?

Run `cargo test`. This change doesn't change the behavior of the lib. 

## Does this PR resolve or contribute to any issues?

No.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
