### PR TITLE
Update circuit info format including type information

### DIFF
--- a/src/bristol_circuit.rs
+++ b/src/bristol_circuit.rs
@@ -9,7 +9,6 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 pub struct BristolCircuit {
     pub wire_count: usize,
     pub info: CircuitInfo,
-    pub io_widths: (Vec<usize>, Vec<usize>),
     pub gates: Vec<Gate>,
 }
 
@@ -47,14 +46,14 @@ impl BristolCircuit {
     pub fn write_bristol<W: Write>(&self, w: &mut W) -> Result<(), BristolCircuitError> {
         writeln!(w, "{} {}", self.gates.len(), self.wire_count)?;
 
-        let (input_widths, output_widths) = &self.io_widths;
-
+        let input_widths = self.info.input_widths();
         write!(w, "{}", input_widths.len())?;
         for width in input_widths {
             write!(w, " {}", width)?;
         }
         writeln!(w)?;
 
+        let output_widths = self.info.output_widths();
         write!(w, "{}", output_widths.len())?;
         for width in output_widths {
             write!(w, " {}", width)?;
@@ -77,20 +76,18 @@ impl BristolCircuit {
         let (gate_count, wire_count) = BristolLine::read(r)?.circuit_sizes()?;
 
         let input_widths = BristolLine::read(r)?.io_widths()?;
-        if input_widths.len() != info.input_name_to_wire_index.len() {
+        if input_widths.len() != info.inputs.len() {
             return Err(BristolCircuitError::Inconsistency {
                 message: "Input count mismatch".into(),
             });
         }
 
         let output_widths = BristolLine::read(r)?.io_widths()?;
-        if output_widths.len() != info.output_name_to_wire_index.len() {
+        if output_widths.len() != info.outputs.len() {
             return Err(BristolCircuitError::Inconsistency {
                 message: "Output count mismatch".into(),
             });
         }
-
-        let io_widths = (input_widths, output_widths);
 
         let mut gates = Vec::new();
         for _ in 0..gate_count {
@@ -108,7 +105,6 @@ impl BristolCircuit {
         Ok(BristolCircuit {
             wire_count,
             info: info.clone(),
-            io_widths,
             gates,
         })
     }
@@ -116,6 +112,10 @@ impl BristolCircuit {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
+    use crate::circuit_info::IOInfo;
+
     use super::*;
     use std::io::{BufReader, Cursor};
 
@@ -127,14 +127,28 @@ mod tests {
             // which doesn't specify the wire names
             wire_count: 4,
             info: CircuitInfo {
-                input_name_to_wire_index: [("input0".to_string(), 0), ("input1".to_string(), 1)]
-                    .iter()
-                    .cloned()
-                    .collect(),
-                constants: Default::default(),
-                output_name_to_wire_index: [("output0".to_string(), 3)].iter().cloned().collect(),
+                constants: vec![],
+                inputs: vec![
+                    IOInfo {
+                        name: "input0".to_string(),
+                        type_: json!("number"),
+                        address: 0,
+                        width: 1,
+                    },
+                    IOInfo {
+                        name: "input1".to_string(),
+                        type_: json!("number"),
+                        address: 1,
+                        width: 1,
+                    },
+                ],
+                outputs: vec![IOInfo {
+                    name: "output0".to_string(),
+                    type_: json!("number"),
+                    address: 3,
+                    width: 1,
+                }],
             },
-            io_widths: (vec![1, 1], vec![1]),
             gates: vec![
                 Gate {
                     inputs: vec![0, 1],
@@ -182,18 +196,27 @@ mod tests {
         assert_eq!(
             BristolCircuit::from_info_and_bristol_string(
                 &CircuitInfo {
-                    input_name_to_wire_index: [
-                        ("input0".to_string(), 0),
-                        ("input1".to_string(), 1)
-                    ]
-                    .iter()
-                    .cloned()
-                    .collect(),
-                    constants: Default::default(),
-                    output_name_to_wire_index: [("output0".to_string(), 3)]
-                        .iter()
-                        .cloned()
-                        .collect(),
+                    constants: vec![],
+                    inputs: vec![
+                        IOInfo {
+                            name: "input0".to_string(),
+                            type_: json!("number"),
+                            address: 0,
+                            width: 1,
+                        },
+                        IOInfo {
+                            name: "input1".to_string(),
+                            type_: json!("number"),
+                            address: 1,
+                            width: 1,
+                        },
+                    ],
+                    outputs: vec![IOInfo {
+                        name: "output0".to_string(),
+                        type_: json!("number"),
+                        address: 3,
+                        width: 1,
+                    }],
                 },
                 "
                     2 4

--- a/src/circuit_info.rs
+++ b/src/circuit_info.rs
@@ -1,16 +1,43 @@
-use std::collections::BTreeMap;
-
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CircuitInfo {
-    pub input_name_to_wire_index: BTreeMap<String, usize>,
-    pub constants: BTreeMap<String, ConstantInfo>,
-    pub output_name_to_wire_index: BTreeMap<String, usize>,
+    pub constants: Vec<ConstantInfo>,
+    pub inputs: Vec<IOInfo>,
+    pub outputs: Vec<IOInfo>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConstantInfo {
-    pub value: String,
-    pub wire_index: usize,
+    pub name: String,
+
+    #[serde(rename = "type")]
+    pub type_: Value,
+
+    pub address: usize, // aka wire_index
+    pub width: usize,
+
+    pub value: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IOInfo {
+    pub name: String,
+
+    #[serde(rename = "type")]
+    pub type_: Value,
+
+    pub address: usize, // aka wire_index
+    pub width: usize,
+}
+
+impl CircuitInfo {
+    pub fn input_widths(&self) -> Vec<usize> {
+        self.inputs.iter().map(|input| input.width).collect()
+    }
+
+    pub fn output_widths(&self) -> Vec<usize> {
+        self.outputs.iter().map(|output| output.width).collect()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,6 @@ mod raw_bristol_circuit;
 
 pub use bristol_circuit::BristolCircuit;
 pub use bristol_circuit_error::BristolCircuitError;
-pub use circuit_info::{CircuitInfo, ConstantInfo};
+pub use circuit_info::{CircuitInfo, ConstantInfo, IOInfo};
 pub use gate::Gate;
 pub use raw_bristol_circuit::RawBristolCircuit;


### PR DESCRIPTION
## What is this PR doing?

Changes the circuit info format:

eg before:

```json
{
  "input_name_to_wire_index": {
    "input": 0
  },
  "constants": {
    "constant_42": {
      "wire_index": 1,
      "value": 42
    }
  },
  "output_name_to_wire_index": {
    "main": 2
  }
}
```

eg after:

```json
{
  "constants": [
    {
      "name": "constant_42",
      "type": "number",
      "address": 1,
      "width": 1,
      "value": 42
    }
  ],
  "inputs": [
    {
      "name": "input",
      "type": "number",
      "address": 0,
      "width": 1
    }
  ],
  "outputs": [
    {
      "name": "main",
      "type": "number",
      "address": 2,
      "width": 1
    }
  ]
}
```

The most important change is the addition of `type` fields, which enable specifying type information for constants, inputs, and outputs. There are downstream changes coming that put `"number"` and `"bool"` in these fields, but the idea is to specify something more comprehensive for rich io, to enable arrays, object (dictionaries) etc.

Next most important is the `width` field, which mirrors the metadata in the bristol circuit (see below). Additionally, the `BristolCircuit` type excludes that metadata and was instead including a hacky `io_widths` field in the top level. This is a replacement for that, and is also a much more readable source of this information than the raw bristol circuit.

<details>
<summary>Click to expand: example of widths in bristol circuit metadata</summary>

```
376 504
2 64 64 // <-- 2 inputs with widths 64 and 64
1 64    // <-- 1 output with width 64

2 1 63 127 376 XOR
2 1 62 126 375 XOR
2 1 61 125 374 XOR
```

(See adder64.txt on https://nigelsmart.github.io/MPC-Circuits/ for the full circuit)
</details>

Other changes:
- Uses arrays instead of objects, with a "name" field instead of relying on the object keys
- Renames `input_name_to_wire_index` to just `inputs` and `output_name_to_wire_index` to just `outputs`
  - This is both more appropriate in the context of updates and fixes the unnecessary verbosity
- The term `address` replaces `wire_index` (takes advantage of similar idea in ordinary computing (wire addresses are much like memory addresses))

## How can these changes be manually tested?

`cargo test`

But really: Make use of it in downstream projects
(Not a good testing story here I know)

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Rich-IO-15ed57e8dd7e80058612d5519bff625b?pvs=4

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
